### PR TITLE
Enables templates for probing in ipv6.

### DIFF
--- a/src/probe_modules/module_ipv6_udp.c
+++ b/src/probe_modules/module_ipv6_udp.c
@@ -306,7 +306,7 @@ int ipv6_udp_make_packet(void *buf, size_t *buf_len, struct in6_addr src_ip,
 
 	udp_header->uh_sum = 0;
 	udp_header->uh_sum = ipv6_payload_checksum(ntohs(udp_header->uh_ulen), &ip6_header->ip6_src, &ip6_header->ip6_dst, (unsigned short *) udp_header, IPPROTO_UDP);
-	
+
 	size_t headers_len = sizeof(struct ether_header) + sizeof(struct ip6_hdr) +
 			     sizeof(struct udphdr);
 	*buf_len = headers_len + udp_send_msg_len;

--- a/src/probe_modules/module_ipv6_udp.c
+++ b/src/probe_modules/module_ipv6_udp.c
@@ -292,6 +292,7 @@ int ipv6_udp_make_packet(void *buf, size_t *buf_len, struct in6_addr src_ip,
 		// The buf is a stack var of our caller of size MAX_PACKET_SIZE
 		// Recalculate the payload using the loaded template
 		payload_len = ipv6_udp_template_build(udp_template, payload, MAX_UDP_PAYLOAD_LEN, ip6_header, udp_header, aes);
+
 		// If success is zero, the template output was truncated
 		if (payload_len <= 0) {
 			log_fatal("udp", "UDP payload template generated an empty payload");
@@ -305,7 +306,7 @@ int ipv6_udp_make_packet(void *buf, size_t *buf_len, struct in6_addr src_ip,
 
 	udp_header->uh_sum = 0;
 	udp_header->uh_sum = ipv6_payload_checksum(ntohs(udp_header->uh_ulen), &ip6_header->ip6_src, &ip6_header->ip6_dst, (unsigned short *) udp_header, IPPROTO_UDP);
-
+	
 	size_t headers_len = sizeof(struct ether_header) + sizeof(struct ip6_hdr) +
 			     sizeof(struct udphdr);
 	*buf_len = headers_len + udp_send_msg_len;

--- a/src/probe_modules/module_ipv6_udp.c
+++ b/src/probe_modules/module_ipv6_udp.c
@@ -38,12 +38,12 @@
 
 static char *udp_send_msg = NULL;
 static int udp_send_msg_len = 0;
-//static int udp_send_substitutions = 0;
+static int udp_send_substitutions = 0;
 static udp_payload_template_t *udp_template = NULL;
 
 static const char *udp_send_msg_default = "GET / HTTP/1.1\r\nHost: www\r\n\r\n";
 
-/*
+
 const char *udp_unreach_strings[] = {
 	"network unreachable",
 	"host unreachable",
@@ -61,7 +61,7 @@ const char *udp_unreach_strings[] = {
 	"communication admin. prohibited",
 	"host presdence violation",
 	"precedence cutoff"
-};*/
+};
 
 const char *ipv6_udp_usage_error =
 	"unknown UDP probe specification (expected file:/path or text:STRING or hex:01020304 or template:/path or template-fields)";
@@ -180,11 +180,8 @@ int ipv6_udp_global_initialize(struct state_conf *conf) {
 		fclose(inp);
 
 		if (strcmp(args, "template") == 0) {
-			// TODO FIXME: Templates in IPv6 are not yet supported
-			log_fatal("udp", "templates not yet supported in IPv6!");
-/*			udp_send_substitutions = 1;
-			udp_template = udp_template_load(udp_send_msg, udp_send_msg_len);
-			*/
+			udp_send_substitutions = 1;
+			udp_template = ipv6_udp_template_load(udp_send_msg, udp_send_msg_len);
 		}
 
 	} else if (strcmp(args, "hex") == 0) {
@@ -268,23 +265,21 @@ int ipv6_udp_prepare_packet(void *buf, macaddr_t *src, macaddr_t *gw, UNUSED voi
 	return EXIT_SUCCESS;
 }
 
-int ipv6_udp_make_packet(void *buf, size_t *buf_len, UNUSED ipaddr_n_t src_ip,
-		UNUSED ipaddr_n_t dst_ip, port_n_t dport, uint8_t ttl, uint32_t *validation, int probe_num, UNUSED uint16_t ip_id, void *arg)
+int ipv6_udp_make_packet(void *buf, size_t *buf_len, struct in6_addr src_ip,
+		struct in6_addr dst_ip, port_n_t dport, uint8_t ttl, uint32_t *validation, int probe_num, UNUSED uint16_t ip_id, void *arg)
 {
 	// From module_ipv6_udp_dns
 	struct ether_header *eth_header = (struct ether_header *) buf;
 	struct ip6_hdr *ip6_header = (struct ip6_hdr*) (&eth_header[1]);
 	struct udphdr *udp_header= (struct udphdr *) &ip6_header[1];
 
-	ip6_header->ip6_src = ((struct in6_addr *) arg)[0];
-	ip6_header->ip6_dst = ((struct in6_addr *) arg)[1];
+	ip6_header->ip6_src = src_ip;
+	ip6_header->ip6_dst = dst_ip;
 	ip6_header->ip6_ctlun.ip6_un1.ip6_un1_hlim = ttl;
 	udp_header->uh_sport = htons(get_src_port(num_ports, probe_num,
 				     validation));
 	udp_header->uh_dport = dport;
 
-	// TODO FIXME
-/*
 	if (udp_send_substitutions) {
 		char *payload = (char *) &udp_header[1];
 		int payload_len = 0;
@@ -297,7 +292,11 @@ int ipv6_udp_make_packet(void *buf, size_t *buf_len, UNUSED ipaddr_n_t src_ip,
 		// The buf is a stack var of our caller of size MAX_PACKET_SIZE
 		// Recalculate the payload using the loaded template
 		payload_len = ipv6_udp_template_build(udp_template, payload, MAX_UDP_PAYLOAD_LEN, ip6_header, udp_header, aes);
-
+		for (int i = 0; i < payload_len; i++) {
+		    printf("%02x", (unsigned char)payload[i]);
+		}
+		printf("\n");
+		log_warn("udp", "loading in UDP template substitutions '%s'\n", payload);
 		// If success is zero, the template output was truncated
 		if (payload_len <= 0) {
 			log_fatal("udp", "UDP payload template generated an empty payload");
@@ -308,10 +307,10 @@ int ipv6_udp_make_packet(void *buf, size_t *buf_len, UNUSED ipaddr_n_t src_ip,
 		ip6_header->ip6_ctlun.ip6_un1.ip6_un1_plen = htons(sizeof(struct udphdr) + payload_len);
 		udp_header->uh_ulen = ntohs(sizeof(struct udphdr) + payload_len);
 	}
-*/
+
 	udp_header->uh_sum = 0;
 	udp_header->uh_sum = ipv6_payload_checksum(ntohs(udp_header->uh_ulen), &ip6_header->ip6_src, &ip6_header->ip6_dst, (unsigned short *) udp_header, IPPROTO_UDP);
-	
+
 	size_t headers_len = sizeof(struct ether_header) + sizeof(struct ip6_hdr) +
 			     sizeof(struct udphdr);
 	*buf_len = headers_len + udp_send_msg_len;
@@ -472,11 +471,30 @@ void ipv6_udp_template_free(udp_payload_template_t *t)
 int ipv6_udp_random_bytes(char *dst, int len, const unsigned char *charset,
 		int charset_len, aesrand_t *aes) {
 	int i;
-	for(i=0; i<len; i++)
-		*dst++ = charset[ (aesrand_getword(aes) & 0xFFFFFFFF) % charset_len ];
+	for(i=0; i<len; i++) {
+		*dst = charset[ (aesrand_getword(aes) & 0xFFFFFFFF) % charset_len ];
+		dst++;
+	}
 	return i;
 }
-/*
+
+// Function to expand IPv6 address
+void expand_ipv6_address(const struct in6_addr *addr, char *expanded, size_t size) {
+    char tmp[INET6_ADDRSTRLEN];
+    inet_ntop(AF_INET6, addr, tmp, sizeof(tmp));
+
+    // Expand the IPv6 address
+    unsigned int blocks[8] = {0};
+    sscanf(tmp, "%x:%x:%x:%x:%x:%x:%x:%x",
+           &blocks[0], &blocks[1], &blocks[2], &blocks[3],
+           &blocks[4], &blocks[5], &blocks[6], &blocks[7]);
+
+    snprintf(expanded, size,
+             "%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x",
+             blocks[0], blocks[1], blocks[2], blocks[3],
+             blocks[4], blocks[5], blocks[6], blocks[7]);
+}
+
 int ipv6_udp_template_build(udp_payload_template_t *t, char *out, unsigned int len,
 	struct ip6_hdr *ip6_header, struct udphdr *udp_hdr, aesrand_t *aes)
 {
@@ -484,6 +502,7 @@ int ipv6_udp_template_build(udp_payload_template_t *t, char *out, unsigned int l
 	char *p;
 	char *max;
 	char tmp[256];
+	char expanded[40]; // Buffer for the expanded IPv6 address
 	int full = 0;
 	unsigned int x, y;
 	uint32_t *u32;
@@ -532,46 +551,44 @@ int ipv6_udp_template_build(udp_payload_template_t *t, char *out, unsigned int l
 
 			// TODO: Condense these case statements to remove redundant code
 			case UDP_SADDR_A:
-				if ( p + 15 >= max) {
+				if ( p + 39 >= max) { // Maximum IPv6 string length is 39
 					full = 1;
 					break;
 				}
 				// Write to stack and then memcpy in order to properly track length
-				inet_ntop(AF_INET, (char *)&ip_hdr->ip_src, tmp, sizeof(tmp)-1);
-				memcpy(p, tmp, strlen(tmp));
-				p += strlen(tmp);
+				expand_ipv6_address(&ip6_header->ip6_src, expanded, sizeof(expanded));
+				memcpy(p, expanded, 39);
+				p += 39;
 				break;
 
 			case UDP_DADDR_A:
-				if ( p + 15 >= max) {
+				if ( p + 39 >= max) { // Maximum IPv6 string length is 39
 					full = 1;
 					break;
 				}
 				// Write to stack and then memcpy in order to properly track length
-				inet_ntop(AF_INET, (char *)&ip_hdr->ip_dst, tmp, sizeof(tmp)-1);
-				memcpy(p, tmp, strlen(tmp));
-				p += strlen(tmp);
+				expand_ipv6_address(&ip6_header->ip6_dst, expanded, sizeof(expanded));
+				memcpy(p, expanded, 39);
+				p += 39;
 				break;
 
 			case UDP_SADDR_N:
-				if ( p + 4 >= max) {
+				if ( p + 16 >= max) {
 					full = 1;
 					break;
 				}
 
-				u32 = (uint32_t *)p;
-				*u32 = ip_hdr->ip_src.s_addr;
-				p += 4;
+				memcpy(p, ip6_header->ip6_src.s6_addr, 16);
+				p += 16;
 				break;
 
 			case UDP_DADDR_N:
-				if ( p + 4 >= max) {
+				if ( p + 16 >= max) {
 					full = 1;
 					break;
 				}
-				u32 = (uint32_t *)p;
-				*u32 = ip_hdr->ip_dst.s_addr;
-				p += 4;
+				memcpy(p, ip6_header->ip6_dst.s6_addr, 16);
+				p += 16;
 				break;
 
 			case UDP_SPORT_N:
@@ -757,7 +774,7 @@ udp_payload_template_t * ipv6_udp_template_load(char *buf, unsigned int len)
 
 	return t;
 }
-*/
+
 static fielddef_t fields[] = {
 	{.name = "classification", .type="string", .desc = "packet classification"},
 	{.name = "success", .type="int", .desc = "is response considered success"},
@@ -780,7 +797,7 @@ probe_module_t module_ipv6_udp = {
 	.thread_initialize = &ipv6_udp_init_perthread,
 	.global_initialize = &ipv6_udp_global_initialize,
 	.prepare_packet = &ipv6_udp_prepare_packet,
-	.make_packet = &ipv6_udp_make_packet,
+	.make_packet_ipv6 = &ipv6_udp_make_packet,
 	.print_packet = &ipv6_udp_print_packet,
 	.validate_packet = &_ipv6_udp_validate_packet,
 	.process_packet = &ipv6_udp_process_packet,

--- a/src/probe_modules/module_ipv6_udp.c
+++ b/src/probe_modules/module_ipv6_udp.c
@@ -292,11 +292,6 @@ int ipv6_udp_make_packet(void *buf, size_t *buf_len, struct in6_addr src_ip,
 		// The buf is a stack var of our caller of size MAX_PACKET_SIZE
 		// Recalculate the payload using the loaded template
 		payload_len = ipv6_udp_template_build(udp_template, payload, MAX_UDP_PAYLOAD_LEN, ip6_header, udp_header, aes);
-		for (int i = 0; i < payload_len; i++) {
-		    printf("%02x", (unsigned char)payload[i]);
-		}
-		printf("\n");
-		log_warn("udp", "loading in UDP template substitutions '%s'\n", payload);
 		// If success is zero, the template output was truncated
 		if (payload_len <= 0) {
 			log_fatal("udp", "UDP payload template generated an empty payload");

--- a/src/probe_modules/module_udp.h
+++ b/src/probe_modules/module_udp.h
@@ -104,3 +104,8 @@ int udp_template_field_lookup(const char *vname, udp_payload_field_t *c);
 
 udp_payload_template_t *udp_template_load(uint8_t *buf, uint32_t buf_len,
 					  uint32_t *max_pkt_len);
+
+udp_payload_template_t * ipv6_udp_template_load(char *buf, unsigned int len);
+
+int ipv6_udp_template_build(udp_payload_template_t *t, char *out, unsigned int len,
+	struct ip6_hdr *ip6_header, struct udphdr *udp_hdr, aesrand_t *aes);

--- a/src/probe_modules/probe_modules.h
+++ b/src/probe_modules/probe_modules.h
@@ -74,6 +74,12 @@ typedef int (*probe_make_packet_cb)(void *packetbuf, size_t *buf_len,
 				    uint32_t *validation, int probe_num,
 				    uint16_t ip_id, void *arg);
 
+typedef int (*probe_make_packet_cb_ipv6)(void *packetbuf, size_t *buf_len,
+				    struct in6_addr src_ip, struct in6_addr dst_ip,
+				    port_n_t dst_port, uint8_t ttl,
+				    uint32_t *validation, int probe_num,
+				    uint16_t ip_id, void *arg);
+
 typedef void (*probe_print_packet_cb)(FILE *, void *packetbuf);
 
 typedef int (*probe_close_cb)(struct state_conf *, struct state_send *,
@@ -106,6 +112,7 @@ typedef struct probe_module {
 	probe_thread_init_cb thread_initialize;
 	probe_prepare_packet_cb prepare_packet;
 	probe_make_packet_cb make_packet;
+	probe_make_packet_cb_ipv6 make_packet_ipv6;
 	probe_print_packet_cb print_packet;
 	probe_validate_packet_cb validate_packet;
 	probe_classify_packet_cb process_packet;


### PR DESCRIPTION
When templates added ip addresses the code still treated them as ipv4 addresses so I updated to handle ipv4 formatting.

The make_packet code in send.c lost the pointer for AES random context. The pointer was overwritten to point to the ip6 src/dst instead. This meant that any time a random number was attempted to be generated we hit a segmentation fault.  To fix this I have updated to create two methods make_packet_ipv6 and make_packet. This allows us to pass the src and dst variables as their own field, and leave the probe_data pointer alone.